### PR TITLE
fix dependencies for python 3.12

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
-PyYAML==6.0
+PyYAML==6.0.1
 
 # For export
 python-dateutil==2.8.2
-influenzanet.surveys[validator]==1.0.5
+influenzanet.surveys[validator]==1.0.6
 influenzanet.api==1.1.*
 cliff==3.10.*


### PR DESCRIPTION
PyYAML 6.0.1 is need for a successful pip install with python 3.12