### PR TITLE
Switching context now correctly initialize api client

### DIFF
--- a/ifncli/appConfig.py
+++ b/ifncli/appConfig.py
@@ -1,0 +1,75 @@
+"""
+App Configuration Manager
+"""
+
+import sys
+
+from .config import ConfigManager, ConfigException
+from .platform import PlatformResources
+from influenzanet.api import ManagementAPIClient
+
+class AppConfigManager(ConfigManager):
+    def __init__(self, cfg_path=None):
+        super().__init__()
+
+        self._configs = {}
+        self._apis = {}
+        self.api_shown = False
+
+        self._cfg_path = cfg_path
+        self._configs = self.load(self._cfg_path)
+
+    def switch(self, name: str):
+        super().switch(name)
+        # reload the configuration
+        self._configs = self.load(self._cfg_path)
+        # clear the cached api client
+        self._apis = {}
+
+    def get_management_api(self):
+        """
+        Helper to get the Management API client. Commands should never instantiate directly the client,
+        but ask for it from this method
+        """
+        if 'management' in self._apis:
+            client = self._apis['management']
+            client.renew_token()
+            return client
+        user_credentials = self._configs["user_credentials"]
+        management_api_url = self._configs["management_api_url"]
+        participant_api_url = self._configs["participant_api_url"]
+
+        client = ManagementAPIClient(management_api_url, user_credentials, participant_api_url, verbose=False)
+        self._apis['management'] = client
+
+        if not self.api_shown:
+            current_context = self.get_current()
+            print("Connected to [%s] <%s>@%s on %s" % (current_context, user_credentials['email'], user_credentials['instanceId'], management_api_url), file=sys.stderr)
+            self.api_shown = True
+
+        return client
+
+    def get_configs(self, what=None, must_exist=True):
+        """
+        Get App configs
+        @param what entry to get, return all if None (default)
+        @param must_exist if True, raise an error if 'what' entry doesnt exists, if False returns None if entry doesnt exist
+        """
+        if what is not None:
+            if not must_exist and what not in self._configs:
+                return None
+            return self._configs[what]
+
+        return self._configs
+
+    def get_platform(self, resources_path=None) -> PlatformResources:
+        """
+        Get The platform object
+        """
+        if resources_path is None:
+            resources_path = self._configs.get('resources_path', None)
+        overrides = self._configs.get('vars', None)
+
+        if resources_path is None:
+            raise ConfigException("Resource path must be provided either in config file or as command option")
+        return PlatformResources(resources_path, overrides=overrides)

--- a/ifncli/commands/config.py
+++ b/ifncli/commands/config.py
@@ -10,13 +10,13 @@ class Login(Command):
     name = 'login'
 
     def take_action(self, parsed_args):
-        cfg = self.app.get_configs()
+        cfg = self.app.appConfigManager.get_configs()
         print("Management API  : %s", cfg["management_api_url"])
         print("Participant API : %s", cfg['participant_api_url'])
         creds = cfg['user_credentials']
         print("Account         : <%s>@%s" % (creds['email'], creds['instanceId']))
         try:
-            api = self.app.get_management_api()
+            api = self.app.appConfigManager.get_management_api()
             print("Login Ok")
         except Exception as e:
             print("Problem during login")
@@ -35,11 +35,11 @@ class ShowConfig(Command):
         return parser
 
     def take_action(self, args):
-        cfg = self.app.get_configs()
+        appConfigManager = self.app.appConfigManager
 
-        cmg = self.app.configManager
+        cfg = appConfigManager.get_configs()
         
-        platform = self.app.get_platform()
+        platform = appConfigManager.get_platform()
 
         creds = cfg['user_credentials']
         
@@ -52,7 +52,10 @@ class ShowConfig(Command):
             print(json.dumps(output))
             return
 
-        print("Configuration in %s, from context '%s' resolved by %s %s" % (cfg['__config_file'], cmg.get_current(), cmg.cfg_from, cmg.context_file))
+        print("Configuration in %s, from context '%s' resolved by %s %s" % (cfg['__config_file'],
+                                                                            appConfigManager.current_context,
+                                                                            appConfigManager.cfg_from,
+                                                                            appConfigManager.context_file))
         
         print("Management API  : %s" % cfg["management_api_url"])
         print("Participant API : %s" % cfg['participant_api_url'])
@@ -76,7 +79,7 @@ class ShowContexts(Command):
     name = 'config:contexts'
 
     def take_action(self, args):
-        cfg = self.app.configManager
+        cfg = self.app.appConfigManager
         print("Known contexts")
         current = cfg.get_current()
         for name, file in cfg.get_contexts().items():
@@ -97,7 +100,7 @@ class SwitchContext(Command):
         return parser
 
     def take_action(self, args):
-        cfg = self.app.configManager
+        cfg = self.app.appConfigManager
         cfg.switch(args.name)
         print("Context switched to '%s'" % (cfg.get_current()))
 

--- a/ifncli/commands/email.py
+++ b/ifncli/commands/email.py
@@ -35,7 +35,7 @@ class UpdateAutoMessage(Command):
 
         dry_run = args.dry_run
 
-        platform: PlatformResources = self.app.get_platform()
+        platform: PlatformResources = self.app.appConfigManager.get_platform()
 
         path = platform.get_path()
 
@@ -124,7 +124,7 @@ class UpdateAutoMessage(Command):
         if 'condition' in email_config:
             autoMessage.setCondition(email_config['condition'])
         
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
         existing_auto_messages = AutoMessageCollection(client.get_auto_messages())
         
         if existing_auto_messages.exists(autoMessage):
@@ -158,7 +158,7 @@ class ListAutoMessages(Command):
         return parser
         
     def take_action(self, args):
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
         existing_auto_messages = AutoMessageCollection(client.get_auto_messages())
         
         def remove_template(trans):
@@ -194,7 +194,7 @@ class EmailTemplate(Command):
 
         dry_run = args.dry_run
 
-        platform: PlatformResources = self.app.get_platform()
+        platform: PlatformResources = self.app.appConfigManager.get_platform()
 
         email_template_folder = args.email_template_folder
         if email_template_folder is None:
@@ -246,7 +246,7 @@ class EmailTemplate(Command):
         if dry_run:
             print("dry-run mode, template %s" % args.name)
         else:
-            client = self.app.get_management_api()
+            client = self.app.appConfigManager.get_management_api()
             r = client.save_email_template(template.toAPI())
             print('saved templates for: ' + args.name)
 
@@ -288,7 +288,7 @@ class SendCustom(Command):
         
     def take_action(self, args):
 
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
 
         study_key = args.study_key
         email_folder_path = args.email_folder

--- a/ifncli/commands/response.py
+++ b/ifncli/commands/response.py
@@ -36,7 +36,7 @@ class ResponseDownloader(Command):
         query_start_time = datetime.strptime(query_start_date, "%Y-%m-%d-%H-%M-%S") if query_start_date is not None else None
         query_end_time = datetime.strptime(query_end_date, "%Y-%m-%d-%H-%M-%S") if query_end_date is not None else None
         
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
             
         exporter = Exporter(profile, client, study_key)
         r = exporter.export(query_start_time, query_end_time, output_folder )
@@ -68,7 +68,7 @@ class ResponseSchemaDownloader(Command):
         output_folder = args.output
         survey_info_text = ""
 
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
         
         
         if output_format == "csv":
@@ -102,7 +102,7 @@ class ResponseExporter(Command):
 
         output_folder = args.output
         
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
             
         exporter = Exporter(profile, client, study_key)
 
@@ -131,7 +131,7 @@ class ResponseBulkExporter(Command):
 
         plan_folder = os.path.dirname(os.path.abspath(args.plan))
         
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
         
         for profile_name in plan['profiles']:
             fp = plan_folder + '/' + profile_name
@@ -154,7 +154,7 @@ class ResponseStats(Command):
         
     def take_action(self, args):
         study_key = args.study
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
         print(client.get_response_statistics(study_key))
 
 class ResponseStatsDaily(Command):
@@ -193,7 +193,7 @@ class ResponseStatsDaily(Command):
             dates = OrderedDict()
             data['dates'] = dates
 
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
 
         start_time = start_time.replace(hour=0, minute=0, second=0)
         while start_time < max_time:

--- a/ifncli/commands/stats.py
+++ b/ifncli/commands/stats.py
@@ -32,7 +32,7 @@ class UserStatsCommand(Command):
 
     def take_action(self, args):
         
-        cfg = self.app.get_configs()
+        cfg = self.app.appConfigManager.get_configs()
 
         instance = cfg['user_credentials']['instanceId']
         

--- a/ifncli/commands/study.py
+++ b/ifncli/commands/study.py
@@ -73,7 +73,7 @@ class CreateStudy(Command):
         secret_file = args.secret_from
 
         if args.study_key:
-            path = self.app.get_platform().get_path()
+            path = self.app.appConfigManager.get_platform().get_path()
             study_path = path.get_study_path(args.study_key).resolve()
             study_props_path = path.get_study_props_file(args.study_key)
             study_rules_path = path.get_study_rules_file(args.study_key)
@@ -159,10 +159,10 @@ class ImportSurvey(Command):
 
         study_key, survey_key = extract_survey_args(args.study_key, args.from_name)
 
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
 
         if survey_key is not None:        
-            path = self.app.get_platform().get_path()
+            path = self.app.appConfigManager.get_platform().get_path()
             survey_path = path.get_survey_file(study_key, survey_key)
         else:
             survey_path = args.survey_json
@@ -225,12 +225,12 @@ class UpdateSurveyRules(Command):
         study_key = args.study_key
         
         if args.default:
-            platform_path = self.app.get_platform().get_path()
+            platform_path = self.app.appConfigManager.get_platform().get_path()
             rules_path = platform_path.get_study_rules_file(study_key)
         else:
             rules_path = args.rules_json_path
 
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
 
         rules = read_json(rules_path)
         client.update_study_rules(study_key, rules)
@@ -255,7 +255,7 @@ class ManageStudyMembers(Command):
         user_id = args.user_id
         user_name = args.user_name
 
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
 
         if action == 'ADD':
             client.add_study_member(study_key, user_id, user_name)
@@ -280,7 +280,7 @@ class ListSurveys(Command):
     def take_action(self, args):
         study_key = args.study_key
        
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
 
         surveys = client.get_surveys_in_study(study_key, extract_infos=True)
 
@@ -311,7 +311,7 @@ class ListStudies(Lister):
     name = 'study:list'
 
     def take_action(self, args):
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
         r = client.get_studies()
         return json_to_list(r, ['id','key','status'])
 
@@ -330,7 +330,7 @@ class ShowStudy(Command):
         return parser
     
     def take_action(self, args):
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
         study = client.get_study(args.study_key)
         if args.json:
             print(to_json(study))
@@ -375,7 +375,7 @@ class ShowSurvey(Command):
         else:
             if args.survey is None:
                 raise Exception("survey argument is missing. I need this to get the survey from the study")
-            client = self.app.get_management_api()
+            client = self.app.appConfigManager.get_management_api()
             survey = client.get_survey_definition(args.study_key, args.survey)
             if survey is None:
                 raise Exception("No survey available for %s:%s" % (args.study_key, args.survey))
@@ -452,7 +452,7 @@ class CustomStudyRules(Command):
         study_key = args.study
         rules_path = args.rules
         dry_run = args.dry_run
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
         
         participants = None
         done_file = None

--- a/ifncli/commands/user.py
+++ b/ifncli/commands/user.py
@@ -83,7 +83,7 @@ class MigrateUser(Command):
         sleep_delay = args.sleep
         dry_run = args.dry_run
 
-        client = self.app.get_management_api()
+        client = self.app.appConfigManager.get_management_api()
         
         new_users = read_json(user_batch_path)
 

--- a/ifncli/config.py
+++ b/ifncli/config.py
@@ -1,5 +1,5 @@
 """
-App configuration management
+File Configuration Manager
 """
 from typing import Dict, List
 import sys
@@ -19,12 +19,13 @@ class ConfigManager:
         self.contexts: Dict[str] = {}
         self.current:str = None
         self.cfg_from = None
- 
+        self.context_file = None
+
     def load(self, cfg_path=None):
         # Warning for common error
         if os.getenv('INF_CONFIG') is not None:
             print("INF_CONFIG is defined, are you sure you didnt mistyped IFN_CONFIG ?")
-        
+
         context_file = os.getenv('IFNCLI_CONTEXT')
         if context_file is not None:
             ctx = read_yaml(context_file)
@@ -41,10 +42,10 @@ class ConfigManager:
                 cfg_path = env_path
                 self.cfg_from = "env:IFN_CONFIG"
             else:
-                self.cfg_form = "arg:--config"
+                self.cfg_from = "arg:--config"
             self.contexts['default'] = cfg_path
             self.current = 'default'
-            
+
         return self.load_context()
 
     def load_context(self, name=None):
@@ -52,7 +53,7 @@ class ConfigManager:
             name = self.current
         if name is None:
             raise ConfigException("Context name is None")
-        cfg_path = self.get_context(name) 
+        cfg_path = self.get_context(name)
         return self.load_config(cfg_path)
 
     def get_context(self, name:str):
@@ -74,7 +75,7 @@ class ConfigManager:
     def get_contexts(self):
         return self.contexts
 
-    def get_current(self,):
+    def get_current(self):
         return self.current
 
     def switch(self, name:str):

--- a/ifncli/shell.py
+++ b/ifncli/shell.py
@@ -1,17 +1,13 @@
 import sys
 import os
-from pathlib import Path
+
 from cliff.app import App
 from cliff.commandmanager import CommandManager
-
-from .utils import read_yaml
 from .commands import get_commands
-from influenzanet.api import ManagementAPIClient
-from .platform import PlatformResources
-from .config import ConfigManager, ConfigException
+from .appConfig import AppConfigManager
 
 class MyApp(App):
-    
+
     def build_option_parser(self, description, version):
         parser = super(MyApp, self).build_option_parser(
             description,
@@ -24,14 +20,6 @@ class MyApp(App):
             default=os.path.join('resources', 'config.yaml')
         )
 
-        # Current loaded config
-        self._configs = {}
-        self._apis = {}
-
-        # Config contexts
-        self.api_shown = False
-
-        self.configManager = ConfigManager()
 
         self.plugin = None
 
@@ -40,7 +28,7 @@ class MyApp(App):
             self.plugin = Plugin()
         except:
             pass
-    
+
        # self.plugin_manager.build_option_parser(parser)
 
         return parser
@@ -55,65 +43,9 @@ class MyApp(App):
             else:
                 name = command.__name__
             self.command_manager.add_command(name.lower(), command)
-    
-    def prepare_to_run_command(self, cmd):
-        """
-            Preparation of the environment 
-        """
-        self._configs = self.configManager.load(cfg_path=self.options.config)
-    
-    def get_management_api(self):
-        """
-            Helper to get the Management API client. Commands should never instanciate directly the client,
-            but ask for it from this method
-        
-        """
-        if 'management' in self._apis:
-            client = self._apis['management']
-            client.renew_token()
-            return client
-        user_credentials = self._configs["user_credentials"]
-        management_api_url = self._configs["management_api_url"]
-        participant_api_url = self._configs["participant_api_url"]
 
-        client = ManagementAPIClient(management_api_url, user_credentials, participant_api_url, verbose=False)
-        self._apis['management'] = client
+        self.appConfigManager = AppConfigManager(self.options.config)
 
-        if not self.api_shown:
-            current_context = self.get_current_context()
-            print("Connected to [%s] <%s>@%s on %s" % (current_context, user_credentials['email'], user_credentials['instanceId'], management_api_url), file=sys.stderr)
-            self.api_shown = True
-
-        return client
-
-    def get_configs(self, what=None, must_exist=True):
-        """
-            Get App configs
-            @param what entry to get, return all if None (default)
-            @param must_exist if True, raise an error if 'what' entry doesnt exists, if False returns None if entry doesnt exist
-        """
-        if what is not None:
-            if not must_exist and what not in self._configs:
-                return None
-            return self._configs[what]
-        
-        return self._configs
-
-    def get_platform(self, resources_path=None)->PlatformResources:
-        """
-            Get The platform object
-        """
-        if resources_path is None:
-            resources_path = self._configs.get('resources_path', None)
-        overrides = self._configs.get('vars', None)
-
-        if resources_path is None:
-            raise ConfigException("Resource path must be provided either in config file or as command option")
-        return PlatformResources(resources_path, overrides=overrides)
-
-    def get_current_context(self):
-        return self.configManager.get_current()
-            
 def main(argv=sys.argv[1:]):
     if len(argv) == 0:
         default_command = os.getenv('IFNCLI_DEFAULT_COMMAND')
@@ -126,6 +58,7 @@ def main(argv=sys.argv[1:]):
             command_manager=CommandManager('ifncli'),
             deferred_help=True,
         )
+
     return app.run(argv)
 
 


### PR DESCRIPTION
Before this patch, switching context within the repl would not reinitialize the api client with the unintended effect for commands to keep targeting the previous context.

I ventured with some refactoring but didn't push too far since it would have required too much time.