### PR TITLE
Fix: sending a custom email template with no variables

### DIFF
--- a/ifncli/managers/messaging/utils.py
+++ b/ifncli/managers/messaging/utils.py
@@ -103,8 +103,10 @@ def bind_vars(data:str, vars:Optional[Dict]):
     """
     built = False
     problems = []
+
     if vars is None:
-        return data, []
+        return data, [], True # no variables to bind
+    
     for p in VAR_REGEXP.findall(data):
 
         built = True
@@ -128,7 +130,8 @@ def bind_content(data, vars):
             problems: List[str] list of problems detected in content ()
     """
     if vars is None:
-        return data, []
+        return data, [], True # no variables to bind
+    
     problems = []
     values, pp = resolve_vars(vars)
     if len(pp) > 0:


### PR DESCRIPTION
When no variables were present the  `bind_content` function returned `content, []` but the calling function always expected three values resulting in a `ValueError: not enough values to unpack (expected 3, got `2)`.

So I added a `True` to the return statement because there are no variables to bind so it can be considered built.

I thought of adding a check if there are variables in the `wrap_layout` function instead but it seemed kind of ugly to me.